### PR TITLE
Fixed issue with sites_config.sql.erb template not including the trailin...

### DIFF
--- a/templates/default/sites_config.sql.erb
+++ b/templates/default/sites_config.sql.erb
@@ -1,9 +1,9 @@
 INSERT IGNORE INTO core_config_data
   (scope, scope_id, path, value)
-  SELECT 'stores', store_id, 'web/unsecure/base_url', 'http://<%= @site[:servername] %>'
+  SELECT 'stores', store_id, 'web/unsecure/base_url', 'http://<%= @site[:servername] %>/'
     FROM core_store WHERE code = '<%= @site[:run_code] %>';
 
 INSERT IGNORE INTO core_config_data
   (scope, scope_id, path, value)
-  SELECT 'stores', store_id, 'web/secure/base_url', 'https://<%= @site[:servername] %>'
+  SELECT 'stores', store_id, 'web/secure/base_url', 'https://<%= @site[:servername] %>/'
     FROM core_store WHERE code = '<%= @site[:run_code] %>';


### PR DESCRIPTION
...g slash on the site URL

This was breaking the include paths etc in Magento, so the trailing slash is required. Schoolboy error.
