### PR TITLE
Feature/safe install on remote db

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -73,22 +73,23 @@ if File.exists?("#{node['magento']['dir']}/install.php")
     --admin_username "#{node['magento']['admin']['user']}" \
     --admin_password "#{node['magento']['admin']['password']}"
     EOH
+
+    log(install) { level :info }
+
+    file "#{node['magento']['dir']}/app/etc/local.xml" do
+      action :delete
+    end
+
+    bash "magento-install-site" do
+      cwd node['magento']['dir']
+      code <<-EOH
+      cd #{node['magento']['dir']}/ && \
+      #{install}
+      EOH
+    end
+
   else
-    install = "echo 'Magento is installed'"
-  end
-
-  log(install) { level :info }
-
-  file "#{node['magento']['dir']}/app/etc/local.xml" do
-    action :delete
-  end
-
-  bash "magento-install-site" do
-    cwd node['magento']['dir']
-    code <<-EOH
-    cd #{node['magento']['dir']}/ && \
-    #{install}
-    EOH
+    log("Magento is installed") { level :info }
   end
 
   include_recipe "chef-magento::config_local"


### PR DESCRIPTION
check for the database existence using magento db client configuration, for not to depend on mysql cookbook and also to be able to detect a remote database (which is particularly important when your main magento app server is different than DB host).

skip local.xml manipulation if database is detected, as otherwise it conflicts with capi/webi-strano based deployed directory structure as it deletes local.xml file (symlink) and creates new file. The recipe still leaves chef-magento::config_local inclusion for non-destructive local.xml changes
