### PR TITLE
amend varnish vcl_fetch not to process the response on non GET

### DIFF
--- a/templates/default/varnish.vcl.erb
+++ b/templates/default/varnish.vcl.erb
@@ -209,6 +209,11 @@ sub vcl_fetch {
          return (deliver);
     }
 
+    # Backend response includes ESI tags
+    if (beresp.http.Surrogate-Control ~ "ESI/1.0") {
+        set beresp.do_esi = true;
+    }
+
     if (req.request != "GET" && req.request != "HEAD") {
         # We only deal with GET and HEAD by default
         return (deliver);
@@ -216,10 +221,6 @@ sub vcl_fetch {
 
     set beresp.grace = 60s;
     set beresp.http.x-url = req.url;
-    # Backend response includes ESI tags
-    if (beresp.http.Surrogate-Control ~ "ESI/1.0") {
-        set beresp.do_esi = true;
-    }
 
     # Current response should not be cached
     if(beresp.http.Set-Cookie ~ "(nocache=1|NEWMESSAGE)") {


### PR DESCRIPTION
If the request is made using post, the headers should be passed to
the client. One common use case is the login functionality, where
Magento will change the session cookie.

Another option would be to make POST requests to be piped instead of
passed. While it would not require checking the fetched response,
it would change the statistics and would also bypass the varnish
timeout (error) handling mechanism.
