### PR TITLE
When magento adminhtml cookie exists, bypass vagrant cache

### DIFF
--- a/templates/default/varnish.vcl.erb
+++ b/templates/default/varnish.vcl.erb
@@ -73,7 +73,7 @@ sub vcl_recv {
         req.request != "DELETE") {
             return (pipe);
     }
-    if (req.url ~ "^/(index.php/)?(<%= @magento['app']['admin_frontname'] %>|api|varnish|directory|\?___store)") {
+    if (req.url ~ "^/(index.php/)?(<%= @magento['app']['admin_frontname'] %>|api|varnish|directory|\?___store)" || req.http.Cookie ~ "adminhtml") {
             return (pipe);
     }
 


### PR DESCRIPTION
Add back check for adminhtml cookie to bipass cache when logged into the admin.
