### PR TITLE
Remove vhost from hosts.erb and hosts recipe

### DIFF
--- a/recipes/hosts.rb
+++ b/recipes/hosts.rb
@@ -24,7 +24,6 @@ template "/etc/hosts" do
   mode 0644
   variables(
     :fqdn => node['fqdn'],
-    :hostname => node['hostname'],
-    :servername => node['magento']['apache']['servername']
+    :hostname => node['hostname']
   )
 end

--- a/templates/default/hosts.erb
+++ b/templates/default/hosts.erb
@@ -1,4 +1,4 @@
-127.0.0.1   <%= @fqdn %> <%= @servername %> <%= @hostname %> localhost localhost.localdomain
+127.0.0.1   <%= @fqdn %> <%= @hostname %> localhost localhost.localdomain
 
 # The following lines are desirable for IPv6 capable hosts
 ::1     ip6-localhost ip6-loopback


### PR DESCRIPTION
Having the vhosts on the /etc/hosts files causes some MTA's such as sendmail to not send outgoing e-mails since it sees the domain as being local, and thus delivers it to the local machine instead.
