### PR TITLE
Feature/fix 500s

### DIFF
--- a/templates/default/varnish.vcl.erb
+++ b/templates/default/varnish.vcl.erb
@@ -226,16 +226,16 @@ sub vcl_fetch {
         set beresp.http.X-Vary = regsub(beresp.http.Vary, ",?\s?User-Agent,?", "\1");
     }
 
-    if (beresp.status >= 500) {
-         set beresp.grace = 60s;
-         return (restart);
-    }
-
     # These status codes should always pass through and never cache.
     if (beresp.status == 503 || beresp.status == 500) {
          set beresp.saintmode = 20s;
 
          return (deliver);
+    }
+
+    if (beresp.status >= 500) {
+         set beresp.grace = 60s;
+         return (restart);
     }
 
     # Backend response includes ESI tags


### PR DESCRIPTION
Because the if to check for generic 5xx errors was placed before the more fine grained one to check for specific 5xx errors, the special behaviour of return (deliver) for status 500 and 503 was not being picked up. This pull request fixes that issue.
