### PR TITLE
add status loopback host for local server-status checks

### DIFF
--- a/templates/default/hosts.erb
+++ b/templates/default/hosts.erb
@@ -1,5 +1,7 @@
 127.0.0.1   <%= @fqdn %> <%= @servername %> <%= @hostname %> localhost localhost.localdomain
 
+127.78.28.87 status-loopback
+
 # The following lines are desirable for IPv6 capable hosts
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet


### PR DESCRIPTION
useful for limiting access in apache to the actual localhost (skipping the requests via varnish as they use 127.0.0.1 apache acl)
