### PR TITLE
Fix type conflit between defaults and validation

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -50,8 +50,8 @@ end
 
 if File.exists?("#{node['magento']['dir']}/install.php")
   if not_installed?
-    url = URI::HTTP.build({:host=>node['magento']['apache']['servername'],:port=>node['magento']['apache']['unsecure_port'],:path=>'/'})
-    secure_url = URI::HTTPS.build({:host=>node['magento']['apache']['servername'],:port=>node['magento']['apache']['secure_port'],:path=>'/'})
+    url = URI::HTTP.build({:host=>node['magento']['apache']['servername'],:port=>Integer(node['magento']['apache']['unsecure_port']),:path=>'/'})
+    secure_url = URI::HTTPS.build({:host=>node['magento']['apache']['servername'],:port=>Integer(node['magento']['apache']['secure_port']),:path=>'/'})
     install =   <<-EOH
     php -f install.php -- \
     --license_agreement_accepted "yes" \


### PR DESCRIPTION
The URI builder validates the port parameter to make sure it is an integer.
Meanwhile, the default values are strings. This causes the recipe to fail,
and breaks compatibility with old configurations where the values are string
as well.
This commit introduces a conversion to Integer on the variable containing the 
port configuration, to make sure it passes validation.
