### PR TITLE
Add dynamic support for cookies on varnish template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,6 +60,7 @@ default['magento']['admin']['lastname'] = "Admin"
 default['magento']['admin']['email'] = "chef@magento.com"
 default['magento']['admin']['user'] = "chef"
 default['magento']['admin']['password'] = '123123pass'
+default['varnish']['cookies'] = ['currency', 'store', 'geoip']
 
 default['magento']['varnish']['backend_servers'] = [
     {

--- a/templates/default/varnish.vcl.erb
+++ b/templates/default/varnish.vcl.erb
@@ -171,7 +171,7 @@ sub vcl_recv {
     if (req.http.Cookie) {
         set req.http.Cookie = ";" + req.http.Cookie;
         set req.http.Cookie = regsuball(req.http.Cookie, "; +", ";");
-        set req.http.Cookie = regsuball(req.http.Cookie, ";(currency|store|geoip)=", "; \1=");
+        set req.http.Cookie = regsuball(req.http.Cookie, ";(<%= node['varnish']['cookies'].join("|") %>)=", "; \1=");
         set req.http.Cookie = regsuball(req.http.Cookie, ";[^ ][^;]*", "");
         set req.http.Cookie = regsuball(req.http.Cookie, "^[; ]+|[; ]+$", "");
 


### PR DESCRIPTION
Allow for cookie names to be configured via an array so different projects can define their own custom cookies.
