### PR TITLE
Override template from original chef-varnish recipe rather than replacing it

### DIFF
--- a/recipes/varnish.rb
+++ b/recipes/varnish.rb
@@ -19,13 +19,14 @@
 
 include_recipe "chef-varnish"
 
-template "#{node['varnish']['config_dir']}/default.vcl" do
-  source "varnish.vcl.erb"
-  owner "root"
-  group "root"
-  mode 0644
-  variables({
+begin
+  t = resources(:template => File.join(node['varnish']['config_dir'], 'default.vcl'))
+  t.source "varnish.vcl.erb"
+  t.cookbook "chef-magento"
+  t.variables({
+    :params => node['varnish'],
     :magento => node['magento']
   })
-  notifies :restart, resources(:service => "varnish"), :delayed
+rescue Chef::Exceptions::ResourceNotFound
+  Chef::Log.warn "could not find template #{node['varnish']['config_dir']}/default.vcl to modify"
 end


### PR DESCRIPTION
Instead of having the chef-magento:varnish recipe copying a template to the host, override the chef-varnish template . This will allow --why-run to report the correct set of changes on the vcl since it won't be replaced by the default one on every run.

This pull request replaces the previous one that contained code not related with this specific feature.
