### PR TITLE
Fix typo in default backend cache name.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@ default['magento']['app']['use_secure_admin'] = "yes"
 default['magento']['app']['multi_session_save'] = "db" # files|db|memcache|redis
 default['magento']['app']['session_memcache_ip'] = "127.0.0.1"
 default['magento']['app']['session_memcache_port'] = "11211"
-default['magento']['app']['backend_cache'] = "file" # apc|memcached|xcache|file|Cm_Cache_Backend_Redis
+default['magento']['app']['backend_cache'] = "File" # apc|memcached|xcache|File|Cm_Cache_Backend_Redis
 default['magento']['app']['slow_backend'] = "database" # database|file
 default['magento']['app']['backend_servers'] = Array.new
 


### PR DESCRIPTION
Default backend cache is "file", but in local.xml it should be written with uppercase "F".
It is fixing this typo.

Without this fix Magento 1.13.0.2 throws an error during every page open request and halts the execution.
It also writes warnings in the system.log:
Warning: include(File.php): failed to open stream: No such file or directory  in /mnt/project/public/lib/Varien/Autoload.php on line 93
Warning: include(): Failed opening 'File.php' for inclusion (include_path='/mnt/project/public/app/code/local:/mnt/project/public/app/code/community:/mnt/project/public/app/code/core:/mnt/project/public/lib:.:/usr/share/pear:/usr/share/php')  in /mnt/project/public/lib/Varien/Autoload.php on line 93