### PR TITLE
Add option for custom write/read config on local.xml template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,7 @@ default['magento']['php']['upload_max_filesize'] = '50M'
 default['magento']['db']['host'] = "localhost"
 default['magento']['db']['database'] = "magentodb"
 default['magento']['db']['username'] = "magentouser"
+default['magento']['db']['model'] = "mysql4"
 default['magento']['db']['read']['host'] = "localhost"
 default['magento']['db']['write']['host'] = "localhost"
 

--- a/templates/default/local.xml.erb
+++ b/templates/default/local.xml.erb
@@ -36,7 +36,7 @@
                     <persistent><![CDATA[false]]></persistent><!-- Persistent DB connection true / false / empty=false -->
                     <active>1</active>
                     <use />
-                    <model>mysql4</model>
+                    <model><%= @magento['db']['model']%></model>
                     <initStatements>SET NAMES utf8</initStatements>
                     <type>pdo_mysql</type>
                 </connection>
@@ -51,7 +51,7 @@
                       <persistent><![CDATA[false]]></persistent><!-- Persistent DB connection true / false / empty=false -->
                       <active>1</active>
                       <use />
-                      <model>mysql4</model>
+                      <model><%= @magento['db']['read']['model'] ? @magento['db']['read']['model'] : @magento['db']['model']%></model>
                       <initStatements>SET NAMES utf8</initStatements>
                       <type>pdo_mysql</type>
                   </connection>
@@ -66,7 +66,7 @@
                       <persistent><![CDATA[false]]></persistent><!-- Persistent DB connection true / false / empty=false -->
                       <active>1</active>
                       <use />
-                      <model>mysql4</model>
+                      <model><%= @magento['db']['write']['model'] ? @magento['db']['write']['model'] : @magento['db']['model']%></model>
                       <initStatements>SET NAMES utf8</initStatements>
                       <type>pdo_mysql</type>
                   </connection>


### PR DESCRIPTION
Add support for different db connection configurations. Useful for split reading and writing on Tungsten clusters, for example.
