### PR TITLE
return hit_for_pass on uncacheable objects

### DIFF
--- a/templates/default/varnish.vcl.erb
+++ b/templates/default/varnish.vcl.erb
@@ -279,10 +279,12 @@ sub vcl_fetch {
     } elseif (beresp.http.Cache-Control ~ "private") {
         # You are respecting the Cache-Control=private header from the backend
         set beresp.http.X-Cacheable = "NO:Cache-Control=private";
-
+        set beresp.ttl = 60s;
         return(hit_for_pass);
     } elseif (beresp.ttl <= 0s) {
         set beresp.http.X-Cacheable = "NO";
+        set beresp.ttl = 60s;
+        return(hit_for_pass);
     } else {
         # Varnish determined the object was cacheable
         remove beresp.http.Set-Cookie;


### PR DESCRIPTION
The default is not executed because of the return statements so this
code should be emulating what is done there. Not setting hit_for_pass
causes multiple requests for the same object to be queued but not be
fulfilled if the object returned is not cacheable.
