### PR TITLE
Support extension to VCLs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -78,7 +78,8 @@ default['magento']['varnish']['trusted_servers'] = [
 ]
 default['magento']['varnish']['ttl_for_static_files'] = '30d'
 default['magento']['varnish']['additional_vcls'] = []
-
+default['magento']['varnish']['additional_recv_subs'] = []
+default['magento']['varnish']['additional_hash_subs'] = []
 # Custom XML Snippet
 default['magento']['global']['custom'] = ''
 

--- a/templates/default/varnish.vcl.erb
+++ b/templates/default/varnish.vcl.erb
@@ -124,6 +124,12 @@ sub vcl_recv {
         return (pass);
     }
 
+    <% if @magento['varnish']['additional_recv_subs'] %>
+        <% @magento['varnish']['additional_recv_subs'].each do |recv_sub| %>
+            call <%= recv_sub %>;
+        <% end %>
+    <% end %>
+
     # Even though there are few possible values for Accept-Encoding, Varnish treats
     # them literally rather than semantically, so even a small difference which makes
     # no difference to the backend can reduce cache efficiency by making Varnish cache
@@ -227,6 +233,13 @@ sub vcl_hash {
     <% if node['varnish']['GeoIP_enabled'] %>
     hash_data(req.http.X-Geo-IP-Country);
     <% end %>
+
+    <% if @magento['varnish']['additional_hash_subs'] %>
+        <% @magento['varnish']['additional_hash_subs'].each do |hash_sub| %>
+            call <%= hash_sub %>;
+        <% end %>
+    <% end %>
+
     return (hash);
 }
 


### PR DESCRIPTION
This allows additional VCLs to be defined and imported into default.vcl. It also allows subs to be called from vcl_recv and vcl_hash, making the default VCL extensible and removing the need for projects to overwrite the provided default template.
