### PR TITLE
Create missing directories recursively

### DIFF
--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -21,17 +21,20 @@ include_recipe "apache2"
 include_recipe "chef-magento::hosts"
 
 directory node['magento']['apache']['docroot'] do
+  recursive true
   mode "0755"
   action :create
 end
 
 directory "#{node['magento']['apache']['docroot']}/#{node['magento']['apache']['servername']}" do
+  recursive true
   mode "0755"
   action :create
   recursive true
 end
 
 directory "#{node['magento']['apache']['docroot']}/#{node['magento']['apache']['servername']}#{node['magento']['apache']['path']}" do
+  recursive true
   mode "0755"
   action :create
   recursive true

--- a/recipes/config_local.rb
+++ b/recipes/config_local.rb
@@ -23,6 +23,12 @@ else
   config_path = node['magento']['dir']
 end
 
+directory config_path do
+  recursive true
+  mode "0755"
+  action :create
+end
+
 template "#{config_path}/app/etc/local.xml" do
   source "local.xml.erb"
   mode 0644


### PR DESCRIPTION
When provisioning empty server, some of magento / apache directories may be missing.
In order to prevent errors, they have to be created recursively.
