### PR TITLE
Cron Cookbook dependency version 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ depends "mysql"
 depends "database", "> 1.3.0"
 depends "apache2"
 depends "memcached"
-depends "cron", "~> 1.4.1"
+depends "cron", "~> 1.4.0"
 # depends "redis" # This Opscode cookbook has an error
 depends "chef-varnish"
 depends "solr"


### PR DESCRIPTION
Cron Cookbook dependency version needs to be amended to address adiscrepancy between Opscode community repo and GitHub
