### PR TITLE
Add default to Apache settings to disable trace

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,7 @@
 # General settings
+# Force Apache to disable Trace for PCI compliance & associated other security scans
+force_default['apache']['traceenable'] = 'Off'
+
 default['magento']['dir'] = "/var/www/magento.development.local/public"
 
 default['magento']['app']['base_path'] = "public/"


### PR DESCRIPTION
Following on from the advice by @shanethehat regarding globally disabling TRACE in Apache, this PR overrides the default Apache variable to set it as "Off"
