### PR TITLE
Stop solr from deleting/re-creating solr config.

### DIFF
--- a/recipes/solr.rb
+++ b/recipes/solr.rb
@@ -19,19 +19,6 @@
 
 include_recipe "solr"
 
-directory node['solr']['config'] do
-    action      :delete
-    recursive   true
-end
-
-remote_directory node['solr']['config'] do
-  source       "solr.config"
-  owner        node['jetty']['user']
-  group        node['jetty']['group']
-  files_owner  node['jetty']['user']
-  files_group  node['jetty']['group']
-  files_backup 0
-  files_mode   "644"
-  purge        true
-  notifies     :restart, resources(:service => "jetty"), :immediately
-end
+conf_dir = resources("remote_directory[#{node['solr']['config']}]")
+conf_dir.cookbook "chef-magento"
+conf_dir.source "solr.config"


### PR DESCRIPTION
"/etc/solr/conf/" was being deleted upon each provision and new config
copied from the "files/solr.config/" directory.

This makes it hard to see actual changes to configuration on opscode
and slows down the dev VM provisioning by 6-10 seconds.

This commit changes the approach to be a wrapper cookbook instead of placing
the files itself.