### PR TITLE
Disable cron

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,6 +57,7 @@ default['magento']['cronjob']['minute'] = "*/5"
 default['magento']['cronjob']['hour'] = "*"
 default['magento']['cronjob']['name'] = "magento-crontab"
 default['magento']['cronjob']['user'] = "root"
+default['magento']['cronjob']['enabled'] = true
 
 default['magento']['sites'] = Array.new
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ license          "Apache 2.0"
 name             "chef-magento"
 description      "Installs/Configures Magento"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.5"
+version          '1.1.0'
 
 depends "php"
 depends "chef-php-extra"

--- a/recipes/crontab.rb
+++ b/recipes/crontab.rb
@@ -25,6 +25,6 @@ cron_d cron[:name] do
   command "#{node['magento']['dir']}/cron.sh"
   user cron[:user]
   mailto  node['magento']['admin']['email']
-  action  :create
+  action  cron[:enabled] ? :create : :delete
 end
 

--- a/recipes/crontab.rb
+++ b/recipes/crontab.rb
@@ -17,14 +17,14 @@
 # limitations under the License.
 #
 
-cron = node[:magento][:cronjob]
+cron = node['magento']['cronjob']
 
-cron_d cron[:name] do
-  minute cron[:minute]
-  hour cron[:hour]
+cron_d cron['name'] do
+  minute cron['minute']
+  hour cron['hour']
   command "#{node['magento']['dir']}/cron.sh"
-  user cron[:user]
+  user cron['user']
   mailto  node['magento']['admin']['email']
-  action  cron[:enabled] ? :create : :delete
+  action  cron['enabled'] ? :create : :delete
 end
 

--- a/recipes/self_signed_ssl.rb
+++ b/recipes/self_signed_ssl.rb
@@ -36,5 +36,5 @@ cookbook_file "#{node['apache']['dir']}/ssl/magento.pem" do
   mode 0644
   owner "root"
   group "root"
-  notifies :run, resources(:bash => "Create SSL Certificates"), :immediately
+  notifies :run, 'bash[Create SSL Certificates]', :immediately
 end

--- a/recipes/solr.rb
+++ b/recipes/solr.rb
@@ -33,5 +33,5 @@ remote_directory node['solr']['config'] do
   files_backup 0
   files_mode   "644"
   purge        true
-  notifies     :restart, resources(:service => "jetty"), :immediately
+  notifies     :restart, 'service[jetty]', :immediately
 end

--- a/spec/crontab_spec.rb
+++ b/spec/crontab_spec.rb
@@ -1,8 +1,39 @@
 require 'chefspec'
 
 describe 'chef-magento::crontab' do
-  let (:chef_run) { ChefSpec::ChefRunner.new.converge 'chef-magento::crontab' }
-  it 'should do something' do
-    pending 'Your recipe examples go here.'
+  context 'default settings are provided' do
+    let (:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+    it 'should set up magento cron' do
+      expect(chef_run).to create_cron_d("magento-crontab")
+    end
+
+    it 'should use the correct cron script' do
+      expect(chef_run).to create_cron_d("magento-crontab").with(:command => "/var/www/magento.development.local/public/cron.sh")
+    end
+
+    it 'should run every 20 minutes per hour' do
+      expect(chef_run).to create_cron_d("magento-crontab").with(:minute => "*/5")
+    end
+
+    it 'should run every hour per day' do
+      expect(chef_run).to create_cron_d("magento-crontab").with(:hour => "*")
+    end
+
+    it 'should run as root' do
+      expect(chef_run).to create_cron_d("magento-crontab").with(:user => "root")
+    end
+  end
+
+  context 'cron is disabled' do
+    let (:chef_run) {
+      ChefSpec::SoloRunner.new do |node|
+        node.set['magento']['cronjob']['enabled'] = false
+      end.converge(described_recipe)
+    }
+
+    it 'should disable the cron job' do
+      expect(chef_run).to delete_cron_d('magento-crontab')
+    end
   end
 end


### PR DESCRIPTION
Add an option to disable the magento cron job. Default behaviour is to create the cron job to preserve BC, but optionally a config flag can delete an existing cron job, which is useful for switching which server will run the cron in a multi-server environment.