### PR TITLE
Change Magento cronjob to run every minute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,10 +50,10 @@ default['magento']['apache']['ssl']['certfile'] = "ssl/magento.pem"
 default['magento']['apache']['ssl']['protocols'] = "All -SSLv2 -SSLv3"
 default['magento']['apache']['ssl']['ciphersuite'] = "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;"
 
-default['magento']['cronjob']['minute'] = "*/5"
+default['magento']['cronjob']['minute'] = "*/1"
 default['magento']['cronjob']['user'] = 'apache'
 
-default['magento']['cronjob']['minute'] = "*/5"
+default['magento']['cronjob']['minute'] = "*/1"
 default['magento']['cronjob']['hour'] = "*"
 default['magento']['cronjob']['name'] = "magento-crontab"
 default['magento']['cronjob']['user'] = "root"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,10 +50,10 @@ default['magento']['apache']['ssl']['certfile'] = "ssl/magento.pem"
 default['magento']['apache']['ssl']['protocols'] = "All -SSLv2 -SSLv3"
 default['magento']['apache']['ssl']['ciphersuite'] = "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;"
 
-default['magento']['cronjob']['minute'] = "*/1"
+default['magento']['cronjob']['minute'] = "*"
 default['magento']['cronjob']['user'] = 'apache'
 
-default['magento']['cronjob']['minute'] = "*/1"
+default['magento']['cronjob']['minute'] = "*"
 default['magento']['cronjob']['hour'] = "*"
 default['magento']['cronjob']['name'] = "magento-crontab"
 default['magento']['cronjob']['user'] = "root"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ license          "Apache 2.0"
 name             "chef-magento"
 description      "Installs/Configures Magento"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '1.2.0'
 
 depends "php"
 depends "chef-php-extra"

--- a/spec/crontab_spec.rb
+++ b/spec/crontab_spec.rb
@@ -13,7 +13,7 @@ describe 'chef-magento::crontab' do
     end
 
     it 'should run every 20 minutes per hour' do
-      expect(chef_run).to create_cron_d("magento-crontab").with(:minute => "*/5")
+      expect(chef_run).to create_cron_d("magento-crontab").with(:minute => "*/1")
     end
 
     it 'should run every hour per day' do

--- a/spec/crontab_spec.rb
+++ b/spec/crontab_spec.rb
@@ -13,7 +13,7 @@ describe 'chef-magento::crontab' do
     end
 
     it 'should run every 20 minutes per hour' do
-      expect(chef_run).to create_cron_d("magento-crontab").with(:minute => "*/1")
+      expect(chef_run).to create_cron_d("magento-crontab").with(:minute => "*")
     end
 
     it 'should run every hour per day' do


### PR DESCRIPTION
Magento EE Support have advised the Magento cronjob should run every minute: "Current versions of Magento are designed around the cron running every minute. If the cron is running less frequently you may see some undesirable behavior. We do not recommend that cron every five minutes."